### PR TITLE
Remove newline char for discontinuity item's String().

### DIFF
--- a/m3u8/discontinuityItem.go
+++ b/m3u8/discontinuityItem.go
@@ -12,5 +12,5 @@ func NewDiscontinuityItem() (*DiscontinuityItem, error) {
 }
 
 func (di *DiscontinuityItem) String() string {
-	return fmt.Sprintf("%s\n", DiscontinuityItemTag)
+	return fmt.Sprintf("%s", DiscontinuityItemTag)
 }

--- a/m3u8/timeItem.go
+++ b/m3u8/timeItem.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	dateTimeFormat = time.RFC3339Nano
+	dateTimeFormat = "2006-01-02T15:04:05.000+0000"
 )
 
 // TimeItem represents EXT-X-PROGRAM-DATE-TIME


### PR DESCRIPTION
New lines are added for everytag in the writer. So this
is unnecessary and adds an empty line in the playlist file.